### PR TITLE
Add launch script for Linux testing environment

### DIFF
--- a/launch-linux.sh
+++ b/launch-linux.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Launch script for running TaskManager on Linux for testing.
+set -euo pipefail
+
+echo "Setting up TaskManager for Linux testing..."
+
+if ! command -v flutter >/dev/null 2>&1; then
+  echo "Flutter SDK not found. Please install Flutter and add it to your PATH."
+  exit 1
+fi
+
+echo "Fetching dependencies..."
+flutter pub get
+
+echo "Running tests..."
+flutter test
+
+echo "Launching application..."
+flutter run -d linux
+


### PR DESCRIPTION
## Summary
- Add `launch-linux.sh` to run TaskManager on Linux
- Script fetches dependencies, runs tests, and launches the app

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68923c1f529483278a4f51308375b9ef