### PR TITLE
feat: add AI queue toggle

### DIFF
--- a/lib/services/jira_service.dart
+++ b/lib/services/jira_service.dart
@@ -25,6 +25,7 @@ class Task {
   final String projectId;
   final String? jiraTicketId; // This will be the same as key for Jira issues
   final Priority priorityEnum;
+  final bool queuedForAI;
 
   Task({
     required this.id,
@@ -45,6 +46,7 @@ class Task {
     required this.projectId,
     this.jiraTicketId,
     this.priorityEnum = Priority.medium,
+    this.queuedForAI = false,
   });
 
   // Getter for isCompleted - checks if status is "Done"
@@ -77,6 +79,7 @@ class Task {
     String? sprintName,
     bool? isInActiveSprint,
     String? projectId,
+    bool? queuedForAI,
   }) {
     return Task(
       id: id,
@@ -97,6 +100,7 @@ class Task {
       projectId: projectId ?? this.projectId,
       jiraTicketId: jiraTicketId ?? this.jiraTicketId,
       priorityEnum: priorityEnum ?? this.priorityEnum,
+      queuedForAI: queuedForAI ?? this.queuedForAI,
     );
   }
 
@@ -136,6 +140,7 @@ class Task {
       'projectId': projectId,
       'jiraTicketId': jiraTicketId,
       'priorityEnum': priorityString,
+      'queuedForAI': queuedForAI,
     };
   }
 
@@ -181,6 +186,7 @@ class Task {
       projectId: json['projectId'] as String,
       jiraTicketId: json['jiraTicketId'] as String?,
       priorityEnum: priorityEnum,
+      queuedForAI: json['queuedForAI'] as bool? ?? false,
     );
   }
 

--- a/lib/ui_task_details.dart
+++ b/lib/ui_task_details.dart
@@ -55,6 +55,13 @@ class _TaskDetailPageState extends State<TaskDetailPage> {
     widget.onTaskUpdated?.call(_task);
   }
 
+  void _toggleAIQueue(bool? value) {
+    setState(() {
+      _task = _task.copyWith(queuedForAI: value ?? false);
+    });
+    widget.onTaskUpdated?.call(_task);
+  }
+
   Future<void> _expandTaskWithAI() async {
     if (widget.project.projectSummary == null || widget.project.projectSummary!.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
@@ -1095,12 +1102,23 @@ class _TaskDetailPageState extends State<TaskDetailPage> {
                     ),
                   ),
                   const SizedBox(height: 12),
+                  Row(
+                    children: [
+                      Checkbox(
+                        value: _task.queuedForAI,
+                        onChanged: _toggleAIQueue,
+                      ),
+                      const SizedBox(width: 8),
+                      const Text('Queue for AI'),
+                    ],
+                  ),
+                  const SizedBox(height: 12),
                   SizedBox(
                     width: double.infinity,
                     child: ElevatedButton.icon(
-                      onPressed: widget.project.projectSummary != null && 
-                               widget.project.projectSummary!.isNotEmpty && 
-                               !_isExpandingTask && 
+                      onPressed: widget.project.projectSummary != null &&
+                               widget.project.projectSummary!.isNotEmpty &&
+                               !_isExpandingTask &&
                                !_isDraftingEmail &&
                                (isEmailTask(_task.description) ? true : !_isExpandingTask)
                         ? (isEmailTask(_task.description) ? _draftEmailWithAI : _expandTaskWithAI)


### PR DESCRIPTION
## Summary
- track whether tasks are queued for AI
- allow toggling AI queue status from schedule cards and task details
- persist and reload the queue with scheduled task storage

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68941f9c6ffc8327b2739b55f1554ce6